### PR TITLE
feat(privacy): add warning modal for destructive privacy changes (Closes #17)

### DIFF
--- a/apps/balados_sync_web/assets/js/privacy-manager-page.ts
+++ b/apps/balados_sync_web/assets/js/privacy-manager-page.ts
@@ -2,7 +2,8 @@
  * Privacy Manager Page - Inline edit mode for podcast privacy levels
  *
  * Handles the pencil icon edit mode for quickly changing podcast privacy levels
- * with AJAX updates and DOM manipulation.
+ * with AJAX updates and DOM manipulation. Also handles privacy warning modal for
+ * destructive changes (changing from public to anonymous/private).
  */
 
 interface PodcastItem extends HTMLElement {
@@ -10,6 +11,14 @@ interface PodcastItem extends HTMLElement {
     feed: string
     currentPrivacy: string
   }
+}
+
+interface PendingPrivacyChange {
+  feed: string
+  newPrivacy: string
+  item: PodcastItem
+  oldPrivacy: string
+  changeBtn: HTMLButtonElement
 }
 
 function attachPodcastItemListeners(item: PodcastItem): void {
@@ -92,6 +101,16 @@ function attachPodcastItemListeners(item: PodcastItem): void {
       return
     }
 
+    // Check if this is a destructive change (public -> anonymous/private)
+    if (isDestructiveChange(currentPrivacy, newPrivacy)) {
+      // Show warning modal and wait for confirmation
+      const confirmed = await showPrivacyWarning(newPrivacy)
+      if (!confirmed) {
+        // User cancelled
+        return
+      }
+    }
+
     try {
       // Show loading state
       changeBtn.disabled = true
@@ -123,6 +142,126 @@ function attachPodcastItemListeners(item: PodcastItem): void {
       changeBtn.disabled = false
       changeBtn.textContent = 'Change'
     }
+  })
+}
+
+/**
+ * Check if changing privacy is destructive (losing data/visibility)
+ * Destructive: public -> anonymous or private
+ * Non-destructive: anything else (recovering, same level, etc)
+ */
+function isDestructiveChange(currentPrivacy: string, newPrivacy: string): boolean {
+  // Only destructive if going FROM public TO anonymous/private
+  return currentPrivacy === 'public' && (newPrivacy === 'anonymous' || newPrivacy === 'private')
+}
+
+/**
+ * Show privacy warning modal and wait for user confirmation
+ * Returns Promise<boolean> - true if confirmed, false if cancelled
+ */
+function showPrivacyWarning(newPrivacy: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const modal = document.getElementById('privacy-warning-modal')
+    if (!modal) {
+      console.error('[Privacy Warning] Modal not found')
+      resolve(true) // Default to allowing change if modal doesn't exist
+      return
+    }
+
+    const levelEl = document.getElementById('privacy-warning-level')
+    const confirmCheckbox = document.getElementById('privacy-warning-confirm') as HTMLInputElement
+    const confirmBtn = document.getElementById('privacy-warning-confirm-btn') as HTMLButtonElement
+    const cancelBtn = document.getElementById('privacy-warning-cancel-btn') as HTMLButtonElement
+    const statsItem = document.getElementById('privacy-warning-stats')
+
+    // Update modal text
+    if (levelEl) {
+      levelEl.textContent = newPrivacy.charAt(0).toUpperCase() + newPrivacy.slice(1)
+    }
+
+    // Reset checkbox and button state
+    if (confirmCheckbox) {
+      confirmCheckbox.checked = false
+    }
+    if (confirmBtn) {
+      confirmBtn.disabled = true
+    }
+
+    // Update stats message based on privacy level
+    if (statsItem) {
+      if (newPrivacy === 'private') {
+        statsItem.style.display = 'none'
+      } else {
+        statsItem.style.display = 'flex'
+      }
+    }
+
+    // Show modal
+    modal.classList.remove('hidden')
+
+    // Handle checkbox change
+    const onCheckboxChange = () => {
+      if (confirmBtn) {
+        confirmBtn.disabled = !confirmCheckbox.checked
+      }
+    }
+
+    // Handle confirm button
+    const onConfirmClick = (e: Event) => {
+      e.preventDefault()
+      cleanup()
+      modal.classList.add('hidden')
+      resolve(true)
+    }
+
+    // Handle cancel button
+    const onCancelClick = (e: Event) => {
+      e.preventDefault()
+      cleanup()
+      modal.classList.add('hidden')
+      resolve(false)
+    }
+
+    // Handle backdrop click
+    const onBackdropClick = (e: MouseEvent) => {
+      if (e.target === modal) {
+        e.preventDefault()
+        cleanup()
+        modal.classList.add('hidden')
+        resolve(false)
+      }
+    }
+
+    // Handle escape key
+    const onEscapeKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !modal.classList.contains('hidden')) {
+        e.preventDefault()
+        cleanup()
+        modal.classList.add('hidden')
+        resolve(false)
+      }
+    }
+
+    // Setup event listeners
+    confirmCheckbox?.addEventListener('change', onCheckboxChange)
+    confirmBtn?.addEventListener('click', onConfirmClick)
+    cancelBtn?.addEventListener('click', onCancelClick)
+    modal.addEventListener('click', onBackdropClick)
+    document.addEventListener('keydown', onEscapeKey)
+
+    // Cleanup function
+    function cleanup() {
+      confirmCheckbox?.removeEventListener('change', onCheckboxChange)
+      confirmBtn?.removeEventListener('click', onConfirmClick)
+      cancelBtn?.removeEventListener('click', onCancelClick)
+      modal.removeEventListener('click', onBackdropClick)
+      document.removeEventListener('keydown', onEscapeKey)
+    }
+
+    // Focus the confirm button
+    setTimeout(() => {
+      cancelBtn?.focus()
+    }, 0)
   })
 }
 

--- a/apps/balados_sync_web/lib/balados_sync_web/controllers/privacy_manager_html/index.html.heex
+++ b/apps/balados_sync_web/lib/balados_sync_web/controllers/privacy_manager_html/index.html.heex
@@ -356,3 +356,70 @@
     </div>
   </div>
 </div>
+<!-- Privacy Warning Modal -->
+<div
+  id="privacy-warning-modal"
+  class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+>
+  <div class="bg-white rounded-lg p-6 max-w-md w-full mx-4 shadow-xl">
+    <!-- Warning Icon & Title -->
+    <div class="flex items-center gap-3 mb-4">
+      <div class="flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-amber-100">
+        <svg class="h-6 w-6 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M12 9v2m0 4v2m0 4v2m6-12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+      </div>
+      <h2 class="text-xl font-bold text-zinc-900">Important Notice</h2>
+    </div>
+    <!-- Message -->
+    <div class="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-6">
+      <p class="text-zinc-800 font-medium mb-3">
+        Changing to
+        <span id="privacy-warning-level" class="font-bold text-amber-700">Anonymous</span>
+        will:
+      </p>
+      <ul class="text-sm text-zinc-700 space-y-2 ml-4">
+        <li class="flex items-start gap-2">
+          <span class="text-red-600 font-bold">✕</span>
+          <span>Hide your past activity from public pages and discovery</span>
+        </li>
+        <li class="flex items-start gap-2">
+          <span class="text-red-600 font-bold">✕</span>
+          <span>Remove you from trending lists</span>
+        </li>
+        <li class="flex items-start gap-2" id="privacy-warning-stats">
+          <span class="text-green-600 font-bold">✓</span>
+          <span>Still contribute to aggregate statistics</span>
+        </li>
+      </ul>
+    </div>
+    <!-- Checkbox to confirm understanding -->
+    <label class="flex items-center gap-3 mb-6 cursor-pointer hover:bg-gray-50 p-2 rounded">
+      <input type="checkbox" id="privacy-warning-confirm" class="w-4 h-4 text-blue-600 rounded" />
+      <span class="text-sm text-zinc-700">
+        I understand and want to proceed
+      </span>
+    </label>
+    <!-- Buttons -->
+    <div class="flex gap-3">
+      <button
+        id="privacy-warning-cancel-btn"
+        class="flex-1 px-4 py-2 text-zinc-700 border border-zinc-300 rounded-lg hover:bg-zinc-50 font-medium transition"
+      >
+        Cancel
+      </button>
+      <button
+        id="privacy-warning-confirm-btn"
+        class="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium disabled:opacity-50 disabled:cursor-not-allowed transition"
+        disabled
+      >
+        Yes, Change Privacy
+      </button>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

Implements a privacy warning modal that alerts users before destructively changing their podcast privacy settings from public to anonymous or private. This prevents accidental loss of activity visibility on public pages and trending lists.

### Changes Made

- **Privacy Warning Modal**: Added modal component that displays consequences of changing to anonymous/private
- **Modal Features**:
  - Shows clear warnings: activity hides from discovery and trending lists
  - Distinction between anonymous (still contributes to stats) and private (no stats)
  - Requires explicit checkbox confirmation before proceeding
  - Supports keyboard navigation (Escape to cancel)
  - Supports backdrop click to cancel

- **Logic Implementation**:
  - `isDestructiveChange()`: Determines if change is destructive (public → anonymous/private only)
  - `showPrivacyWarning()`: Promise-based modal handler with full event management
  - Non-destructive changes (recovering visibility) bypass the warning

### CQRS/ES Implementation

No CQRS/ES changes required - this is purely a UI enhancement for the privacy manager page. The backend privacy change mechanism remains unchanged.

### Test Plan

- [x] Modal appears when changing public → anonymous
- [x] Modal appears when changing public → private  
- [x] Modal does NOT appear for non-destructive changes (e.g., anonymous → public)
- [x] Checkbox must be checked to enable confirm button
- [x] Escape key closes modal and cancels change
- [x] Backdrop click closes modal and cancels change
- [x] Confirming modal proceeds with privacy change as before
- [x] No regressions to existing privacy change functionality

### Database Changes

None - frontend only change.

### Documentation

- Added comprehensive JSDoc comments to new functions
- Code follows existing TypeScript patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>