### PR TITLE
feat(timeline): add public timeline page with activity feed (Closes #20)

### DIFF
--- a/apps/balados_sync_web/lib/balados_sync_web/controllers/public_html.ex
+++ b/apps/balados_sync_web/lib/balados_sync_web/controllers/public_html.ex
@@ -44,4 +44,35 @@ defmodule BaladosSyncWeb.PublicHTML do
   end
 
   def time_ago_in_words(_), do: "Unknown"
+
+  @doc """
+  Get event type color for border styling.
+  """
+  def event_border_color("subscribe"), do: "border-green-400"
+  def event_border_color("play"), do: "border-blue-400"
+  def event_border_color("unsubscribe"), do: "border-red-400"
+  def event_border_color(_), do: "border-zinc-300"
+
+  @doc """
+  Display username or "Anonymous" based on privacy level.
+  """
+  def display_username(%{"privacy" => "anonymous"}), do: "Anonymous"
+  def display_username(%{"username" => nil}), do: "Anonymous"
+  def display_username(%{"username" => username}), do: "@#{username}"
+  def display_username(_), do: "Anonymous"
+
+  @doc """
+  Get event action text based on event type.
+  """
+  def event_action_text("subscribe"), do: " subscribed to "
+  def event_action_text("play"), do: " listened to "
+  def event_action_text("unsubscribe"), do: " unsubscribed from "
+  def event_action_text(_), do: " interacted with "
+
+  @doc """
+  Get podcast title from event with fallback.
+  """
+  def podcast_title(%{"feed_metadata" => %{"title" => title}}) when is_binary(title), do: title
+  def podcast_title(%{"event_data" => %{"feed_title" => title}}) when is_binary(title), do: title
+  def podcast_title(_), do: "Unknown Podcast"
 end

--- a/apps/balados_sync_web/lib/balados_sync_web/controllers/public_html/timeline.html.heex
+++ b/apps/balados_sync_web/lib/balados_sync_web/controllers/public_html/timeline.html.heex
@@ -1,0 +1,103 @@
+<div class="px-4 py-10 sm:px-6 lg:px-8">
+  <div class="mx-auto max-w-3xl">
+    <!-- Header -->
+    <div class="mb-8">
+      <h1 class="text-4xl font-bold text-zinc-900">Public Timeline</h1>
+      <p class="text-zinc-600 mt-2">
+        See what the Balados community is listening to right now
+      </p>
+    </div>
+    <!-- Timeline Feed -->
+    <div class="space-y-4">
+      <%= if Enum.empty?(@events) do %>
+        <div class="bg-white shadow rounded-lg p-8 text-center text-zinc-500">
+          <p>No activity yet. Be the first to subscribe to a podcast!</p>
+        </div>
+      <% else %>
+        <%= for event <- @events do %>
+          <div class={[
+            "bg-white border-l-4 rounded-lg p-4 shadow-sm hover:shadow-md transition-shadow",
+            event_border_color(event["event_type"])
+          ]}>
+            <div class="flex gap-4">
+              <!-- Podcast Cover -->
+              <%= if event["feed_metadata"] && event["feed_metadata"]["cover"] do %>
+                <div class="flex-shrink-0">
+                  <img
+                    src={event["feed_metadata"]["cover"]["src"]}
+                    alt={event["feed_metadata"]["title"]}
+                    class="w-16 h-16 sm:w-20 sm:h-20 rounded-lg object-cover shadow"
+                  />
+                </div>
+              <% else %>
+                <div class="flex-shrink-0 w-16 h-16 sm:w-20 sm:h-20 rounded-lg bg-zinc-200 flex items-center justify-center">
+                  <span class="text-zinc-400 text-xs">No Cover</span>
+                </div>
+              <% end %>
+              <!-- Event Content -->
+              <div class="flex-1 min-w-0">
+                <div class="flex items-start justify-between gap-2">
+                  <div class="flex-1 min-w-0">
+                    <!-- Username -->
+                    <span class="font-semibold text-zinc-900">
+                      <%= display_username(event) %>
+                    </span>
+                    <!-- Event Action -->
+                    <span class="text-zinc-700">
+                      <%= event_action_text(event["event_type"]) %>
+                    </span>
+                    <!-- Podcast Title -->
+                    <.link
+                      navigate={~p"/podcasts/#{event["rss_source_feed"]}"}
+                      class="font-semibold text-blue-600 hover:underline"
+                    >
+                      <%= podcast_title(event) %>
+                    </.link>
+                    <!-- Episode Title (for plays) -->
+                    <%= if event["event_type"] == "play" && event["event_data"]["item_title"] do %>
+                      <div class="text-sm text-zinc-600 mt-1">
+                        Episode: <%= event["event_data"]["item_title"] %>
+                      </div>
+                    <% end %>
+                  </div>
+                  <!-- Timestamp -->
+                  <time class="text-sm text-zinc-500 whitespace-nowrap">
+                    <%= time_ago_in_words(event["event_timestamp"]) %>
+                  </time>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+    <!-- Pagination -->
+    <%= if @has_previous or @has_next do %>
+      <div class="mt-8 flex justify-between items-center">
+        <%= if @has_previous do %>
+          <.link
+            navigate={~p"/timeline?limit=#{@limit}&offset=#{max(@offset - @limit, 0)}"}
+            class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 transition"
+          >
+            ← Previous
+          </.link>
+        <% else %>
+          <div></div>
+        <% end %>
+
+        <span class="text-sm text-zinc-600">Page <%= @current_page %></span>
+
+        <%= if @has_next do %>
+          <.link
+            navigate={~p"/timeline?limit=#{@limit}&offset=#{@offset + @limit}"}
+            class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 transition"
+          >
+            Next →
+          </.link>
+        <% else %>
+          <div></div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/apps/balados_sync_web/lib/balados_sync_web/router.ex
+++ b/apps/balados_sync_web/lib/balados_sync_web/router.ex
@@ -45,6 +45,7 @@ defmodule BaladosSyncWeb.Router do
     # Public discovery pages
     get "/trending/podcasts", PublicController, :trending_podcasts_html
     get "/trending/episodes", PublicController, :trending_episodes_html
+    get "/timeline", PublicController, :timeline_html
     get "/podcasts/:feed", PublicController, :feed_page
     get "/episodes/:item", PublicController, :episode_page
 


### PR DESCRIPTION
## Summary

Implements a public timeline page at `/timeline` that displays a real-time feed of community podcast activity. This enables social discovery by showing what users are subscribing to and listening to.

### Changes Made

- **Timeline Controller Action**: New `timeline_html/2` action in PublicController
  - Queries PublicEvent projection with LEFT JOIN to User for usernames
  - Supports pagination (limit/offset, default 50, max 100)
  - Batch fetches RSS metadata for unique feeds
  - Enriches events with podcast metadata (title, cover)

- **Template**: New timeline.html.heex template
  - Event cards with color-coded borders (subscribe=green, play=blue, unsubscribe=red)
  - Podcast cover images with fallback placeholder
  - Username or 'Anonymous' based on privacy level
  - Relative timestamps (e.g., '2h ago')
  - Previous/Next pagination buttons

- **Helper Functions**: Added to public_html.ex
  - `event_border_color/1` - color by event type
  - `display_username/1` - mask anonymous users
  - `event_action_text/1` - verb for action (subscribed to, listened to)
  - `podcast_title/1` - extract title with fallback

- **Route**: `GET /timeline` in public browser scope

### CQRS/ES Compliance

✅ Read-only feature (no commands/events)
✅ Uses existing PublicEvent projection
✅ No mutations to event store or aggregates

### Architecture Decisions

- **Query**: Inline in controller (follows trending pages pattern)
- **Metadata Enrichment**: Real-time with RssCache (5min TTL)
- **Pagination**: Simple Previous/Next buttons (not infinite scroll)
- **Privacy**: LEFT JOIN + masking (anonymous users show 'Anonymous')
- **Performance**: Batch metadata fetch, database indexes utilized

### Test Plan

- [ ] Timeline page loads at `/timeline`
- [ ] Displays 50 events by default
- [ ] Shows username or 'Anonymous' based on privacy
- [ ] Podcast covers display with fallback
- [ ] Subscribe events green, play events blue
- [ ] Pagination Previous/Next buttons work
- [ ] Page numbers increment correctly
- [ ] Empty state message shows for new communities
- [ ] Metadata fetch gracefully fails (Unknown Podcast)
- [ ] Mobile responsive layout

### Database Changes

None - uses existing PublicEvent projection.

### Documentation

Updates needed (see follow-up):
- Add to `docs/FEATURES.md` (v1.7 section)
- Add to `CLAUDE.md` (Fonctionnalités Implémentées)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>