### PR TITLE
fix(websocket): implement keep-alive ping/pong and extend timeout

### DIFF
--- a/apps/balados_sync_web/lib/balados_sync_web/controllers/live_websocket_controller.ex
+++ b/apps/balados_sync_web/lib/balados_sync_web/controllers/live_websocket_controller.ex
@@ -12,6 +12,9 @@ defmodule BaladosSyncWeb.LiveWebSocketController do
   Upgrades HTTP request to WebSocket.
 
   Called at GET /api/v1/live and GET /sync/api/v1/live routes.
+
+  Timeout is set to 5 minutes (300_000 ms) to allow long-lived connections.
+  Periodic ping/pong keep-alive is handled in the WebSocket handler.
   """
   def upgrade(conn, _params) do
     Logger.debug("WebSocket upgrade requested from #{inspect(conn.remote_ip)}")
@@ -20,7 +23,7 @@ defmodule BaladosSyncWeb.LiveWebSocketController do
       conn,
       BaladosSyncWeb.LiveWebSocket,
       %{},
-      timeout: 60_000,
+      timeout: 300_000,
       compress: false,
       max_frame_size: 65_536
     )


### PR DESCRIPTION
## Summary

Implement WebSocket keep-alive mechanism to prevent connection timeout for long-lived connections.

## Changes

- Send periodic ping frames every 30 seconds from server
- Handle pong responses from clients gracefully
- Extend idle timeout from 60s to 5 minutes (300s) to accommodate keep-alive interval
- Log ping/pong activity for debugging connection health

## Problem

WebSocket connections would drop after 60 seconds of inactivity without any message exchange (issue #8). This prevented long-lived connections from working properly and required clients to reconnect frequently.

## Solution

Implemented the standard WebSocket ping/pong keep-alive mechanism:
- Server sends a ping frame every 30 seconds
- Client automatically responds with a pong frame
- Connection timeout extended to 5 minutes to allow for this keep-alive pattern
- Both ping and pong are logged for debugging

## Test Plan

- Compile and verify no errors
- Long-lived connections should remain stable beyond 60 seconds
- Ping/pong messages appear in logs
- Connections still timeout properly if completely idle

Closes #8