### PR TITLE
refactor(tests): migrate in_memory_dispatch_test to CommandedCase (Closes #81)

### DIFF
--- a/apps/balados_sync_core/test/balados_sync_core/integration/in_memory_dispatch_test.exs
+++ b/apps/balados_sync_core/test/balados_sync_core/integration/in_memory_dispatch_test.exs
@@ -7,19 +7,18 @@ defmodule BaladosSyncCore.Integration.InMemoryDispatchTest do
   1. Commands can be dispatched through the In-Memory EventStore
   2. Events are stored in-memory (not PostgreSQL)
   3. The EventStore reset provides test isolation
+
+  Uses CommandedCase which automatically:
+  - Resets the In-Memory EventStore before each test
+  - Sets up Ecto sandboxes for proper isolation
+  - Provides common aliases (Dispatcher, SystemRepo, ProjectionsRepo)
   """
 
-  use ExUnit.Case, async: true
+  use BaladosSyncCore.CommandedCase, async: true
 
   alias BaladosSyncCore.Commands.Subscribe
-  alias BaladosSyncCore.Dispatcher
 
   describe "In-Memory EventStore integration" do
-    setup do
-      # Reset In-Memory EventStore before each test
-      :ok = Commanded.EventStore.Adapters.InMemory.reset!(Dispatcher)
-      :ok
-    end
 
     test "dispatching Subscribe command succeeds" do
       user_id = Ecto.UUID.generate()


### PR DESCRIPTION
## Summary

Migrates `in_memory_dispatch_test.exs` to use `BaladosSyncCore.CommandedCase` instead of manual EventStore reset, as recommended in the PR #78 review.

### Changes

- **in_memory_dispatch_test.exs**: 
  - Replaced `use ExUnit.Case` with `use BaladosSyncCore.CommandedCase`
  - Removed manual setup block with EventStore reset
  - Updated moduledoc to document CommandedCase benefits

- **commanded_case.ex**: 
  - Made `setup_sandbox/1` gracefully handle repos that aren't started
  - Added `repo_started?/1` helper to check if a repo process exists
  - This allows tests to run in isolation (e.g., `balados_sync_core` only)

### Benefits

1. **DRY**: Removes duplicate EventStore reset code
2. **Consistency**: Aligns with other integration tests
3. **Future-proof**: Ready for projection verification tests (issue #82)
4. **Robustness**: CommandedCase now works when run from individual apps

## Test Plan

- [x] All 3 tests in `in_memory_dispatch_test.exs` pass
- [x] All 26 tests in `balados_sync_core` pass
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)