### PR TITLE
feat(accessibility): improve toast notifications for screen readers (Closes #52)

### DIFF
--- a/apps/balados_sync_web/assets/js/toast_notifications.ts
+++ b/apps/balados_sync_web/assets/js/toast_notifications.ts
@@ -56,13 +56,19 @@ class ToastManager {
 
   /**
    * Setup keyboard event handlers for accessibility
+   * Note: This is a singleton instance, so the event listener is intentionally
+   * never removed. The ToastManager is created once and lives for the page lifetime.
    */
   private setupKeyboardHandlers(): void {
     document.addEventListener('keydown', (e) => {
-      // Escape key dismisses the most recent toast
+      // Escape key dismisses the most recent VISIBLE toast
+      // Only the first maxVisible toasts are rendered, so we must dismiss from those
       if (e.key === 'Escape' && this.toasts.length > 0) {
-        const latestToast = this.toasts[this.toasts.length - 1]
-        this.dismiss(latestToast.id)
+        const visibleToasts = this.toasts.slice(0, this.maxVisible)
+        if (visibleToasts.length > 0) {
+          const latestVisibleToast = visibleToasts[visibleToasts.length - 1]
+          this.dismiss(latestVisibleToast.id)
+        }
       }
     })
   }


### PR DESCRIPTION
## Summary

Enhances toast notifications with comprehensive accessibility support for screen readers and keyboard users, following WCAG 2.1 guidelines.

## Changes

### ARIA Support
- **Container**: Added `aria-live="polite"`, `role="region"`, `aria-label="Notifications"`
- **Toasts**: Added `role="alert"` for errors (urgent), `role="status"` for others
- **Atomic updates**: Added `aria-atomic="true"` for complete content announcements
- **Type labels**: Added screen reader-only type labels ("Success:", "Error:", etc.)
- **Dismiss button**: Descriptive `aria-label` with message content
- **Icons**: Marked decorative with `aria-hidden="true"`

### Keyboard Navigation
- **Escape key**: Dismisses most recent toast
- Global keydown listener in `setupKeyboardHandlers()`

### Visual Focus
- **Focus ring**: Type-specific colors (`focus:ring-blue-500`, etc.)
- **Focus offset**: Added `focus:ring-offset-2` for visibility
- **Rounded focus**: Added `rounded` class for consistent appearance

### Code Quality
- Replaced inline `onclick` with proper event listener
- Added `TYPE_LABELS` constant for maintainability
- Enhanced JSDoc comments

## Acceptance Criteria

- [x] Add `aria-live='polite'` and `role='status'` to toast container
- [x] Add `aria-label` describing toast type and content
- [x] Implement Escape key to dismiss current toast
- [x] Add visual focus indicator for dismiss button
- [x] Ensure color not sole indicator (icons + text labels)

## Test Plan

1. Open `/timeline` page
2. Trigger a toast notification
3. Verify screen reader announces the toast content
4. Press Escape key - toast should dismiss
5. Tab to dismiss button - verify visible focus ring
6. Click dismiss button - toast should close

🤖 Generated with [Claude Code](https://claude.com/claude-code)