### PR TITLE
docs: fix remaining nice-to-have items (Closes #242)

### DIFF
--- a/docs/technical/CQRS_PATTERNS.md
+++ b/docs/technical/CQRS_PATTERNS.md
@@ -95,6 +95,10 @@ def rebuild_aggregate(stream_id) do
 end
 ```
 
+> **Note** : Le même pattern s'applique aux 4 aggregates bounded context
+> (`Subscription`, `PlayTracking`, `Playlist`, `Collection`), chacun avec
+> son propre stream prefix et état initial.
+
 ---
 
 ## CQRS Pattern
@@ -540,9 +544,10 @@ Depuis le split en bounded contexts (#148), les checkpoints sont par aggregate :
 %CollectionCheckpoint{user_id, collections, timestamp}
 ```
 
-**Legacy** : L'ancien `UserCheckpoint` monolithique est toujours supporté par
-les projectors pour la compatibilité avec les events déjà stockés. Les nouveaux
-snapshots émettent les 4 variants ci-dessus.
+**Legacy** : L'ancien `BaladosSyncCore.Events.UserCheckpoint` monolithique
+(dans `events/user_checkpoint.ex`) est toujours supporté par les projectors
+pour la compatibilité avec les events déjà stockés. Les nouveaux snapshots
+émettent les 4 variants ci-dessus.
 
 ### SnapshotWorker
 


### PR DESCRIPTION
## Summary

Fixes remaining nice-to-have items from PR #241 review.

- Add note to `rebuild_aggregate` example that the pattern applies to all 4 bounded context aggregates
- Clarify legacy `UserCheckpoint` with full module path (`BaladosSyncCore.Events.UserCheckpoint`)
- Verified FEATURES.md has no remaining "User aggregate" references (the review flagged this but it was already clean)

## Test plan

- [ ] Verify rebuild_aggregate note is clear and accurate
- [ ] Verify UserCheckpoint module path matches actual code
- [ ] Grep for any remaining "User aggregate" references

🤖 Generated with [Claude Code](https://claude.com/claude-code)