### PR TITLE
docs: add stream prefix examples to CQRS patterns

### DIFF
--- a/docs/technical/CQRS_PATTERNS.md
+++ b/docs/technical/CQRS_PATTERNS.md
@@ -104,6 +104,11 @@ end
 > | `PlayTracking` | `play_tracking-{user_id}` | `%PlayTracking{}` |
 > | `Playlist` | `playlist-{user_id}` | `%Playlist{}` |
 > | `Collection` | `collection-{user_id}` | `%Collection{}` |
+>
+> Les noms courts sont utilisés ici à titre illustratif. Les modules complets
+> sont `BaladosSyncCore.Aggregates.<Aggregate>` (ex: `BaladosSyncCore.Aggregates.Subscription`).
+>
+> Le `user_id` est un UUID v4 (ex: `subscription-550e8400-e29b-41d4-a716-446655440000`).
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a table showing stream prefix and initial state for all 4 bounded context aggregates alongside the `rebuild_aggregate` code example

Addresses nice-to-have from PR #243 review.

## Test plan
- [ ] Verify markdown table renders correctly
- [ ] Verify stream prefixes match actual implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)